### PR TITLE
fix: Remove city, country & remove underscore from messages

### DIFF
--- a/src/modules/welcome/welcome.service.ts
+++ b/src/modules/welcome/welcome.service.ts
@@ -362,7 +362,7 @@ export class WelcomeService {
       );
     } else if (callbackData?.startsWith('edit_')) {
       const field = callbackData.split('_').slice(1).join('_');
-      await ctx.editMessageText(`Please enter your new ${field.replace('_', ' ')}:`);
+      await ctx.editMessageText(`Please enter your new ${field.replaceAll('_', ' ')}:`);
       this.userSteps.set(userId, `edit_${field}`);
     } else if (callbackData === 'back_to_start') {
       await ctx.deleteMessage();


### PR DESCRIPTION
As per title

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Improvements**
  - Removed "Country" and "City" options from the profile edit menu.
  - Enhanced prompt text for editing profile fields by ensuring all underscores in field names are replaced with spaces for better readability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->