### PR TITLE
fix: Remove mute functionality on non-supergroups

### DIFF
--- a/src/modules/welcome/welcome.service.ts
+++ b/src/modules/welcome/welcome.service.ts
@@ -244,11 +244,13 @@ export class WelcomeService {
         });
 
         // Mute the user and send a verification message
-        await ctx.telegram.restrictChatMember(chatId, member.id, {
-          permissions: {
-            can_send_messages: false,
-          },
-        });
+        if (ctx.chat?.type === 'supergroup') {
+          await ctx.telegram.restrictChatMember(chatId, member.id, {
+            permissions: {
+              can_send_messages: false,
+            },
+          });
+        }
 
         const botUsername = process.env.BOT_USERNAME;
         const deepLink = `https://t.me/${botUsername}?start=register_${member.id}_${chatId}`;


### PR DESCRIPTION
As per title...

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved handling of new chat members to ensure muting is only applied in supergroup chats, preventing errors or unintended behavior in other chat types.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->