### PR TITLE
fix: Remove unmute functionality on non-supergroups

### DIFF
--- a/src/modules/welcome/welcome.service.ts
+++ b/src/modules/welcome/welcome.service.ts
@@ -735,17 +735,19 @@ export class WelcomeService {
       // Enable group permissions
       const groupId = userData.group_id;
       if (groupId) {
-        await ctx.telegram.restrictChatMember(groupId, Number(userId), {
-          permissions: {
-            can_send_messages: true,
-            can_send_polls: true,
-            can_send_other_messages: true,
-            can_add_web_page_previews: true,
-            can_change_info: false,
-            can_invite_users: true,
-            can_pin_messages: false,
-          },
-        });
+        if (ctx.chat?.type === 'supergroup') {
+          await ctx.telegram.restrictChatMember(groupId, Number(userId), {
+            permissions: {
+              can_send_messages: true,
+              can_send_polls: true,
+              can_send_other_messages: true,
+              can_add_web_page_previews: true,
+              can_change_info: false,
+              can_invite_users: true,
+              can_pin_messages: false,
+            },
+          });
+        }
 
         const welcomeMessage = await ctx.telegram.sendMessage(
           groupId,


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved group permission handling to ensure user permissions are only updated in supergroup chats after registration and Ninja Turtle selection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->