### PR TITLE
fix: Always prompt city join confirmation for users joining a new city

### DIFF
--- a/src/modules/welcome/welcome.service.ts
+++ b/src/modules/welcome/welcome.service.ts
@@ -224,15 +224,16 @@ export class WelcomeService {
 
     if (message?.new_chat_members) {
       for (const member of message.new_chat_members) {
-        // Check if the user is already registered
+        // Check if the city exists for the group id
         const cityDetails = await this.cityService.getCityByGroupId(String(chatId));
-        if (cityDetails) {
-          if (
-            await this.membershipService.checkUserCityMembership(String(member.id), cityDetails.id)
-          ) {
-            return;
-          }
-        }
+        if (!cityDetails) return;
+
+        // Check if the user already has a membership with the city
+        const hasMembership = await this.membershipService.checkUserCityMembership(
+          String(member.id),
+          cityDetails.id,
+        );
+        if (hasMembership) return;
 
         // Store the group_id in userGroupMap
         this.userGroupMap.set(String(member.id), {


### PR DESCRIPTION
Bot sends a confirmation message to users when they join another city, asking them to confirm if they want to be part of this city. However, the current condition causes this confirmation step to be skipped, preventing users from explicitly confirming their participation in the new city. This PR addresses that logic to ensure users always receive the confirmation prompt when joining a new city.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Users who confirm their city registration now automatically receive permissions to participate in group activities, such as sending messages and polls.

- **Bug Fixes**
  - All new chat members are now properly processed and muted for verification, regardless of existing registration status.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->