### PR TITLE
feat: Add PrivateChatMiddleware to handle message filtering for private chats

### DIFF
--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -11,6 +11,7 @@ import { UserModule } from './modules/user/user.module';
 import { CountryModule } from './modules/country/country.module';
 import { CityModule } from './modules/city/city.module';
 import { CommonModule } from './modules/common/common.module';
+import { PrivateChatMiddleware } from './middleware/chat-type.middleware';
 
 // Load environment variables
 config();
@@ -36,6 +37,7 @@ config();
                   },
                 }
               : {},
+          middlewares: [new PrivateChatMiddleware().use()],
         };
       },
       inject: [ConfigService],

--- a/src/middleware/chat-type.middleware.ts
+++ b/src/middleware/chat-type.middleware.ts
@@ -1,0 +1,20 @@
+import { Context, MiddlewareFn } from 'telegraf';
+import { Injectable } from '@nestjs/common';
+
+@Injectable()
+export class PrivateChatMiddleware {
+  use(): MiddlewareFn<Context> {
+    return (ctx, next) => {
+      // Allow all non-message updates (inline queries, callback queries, etc.)
+      if (!ctx.chat && ctx.inlineQuery) {
+        return next(); // allow inline mode
+      }
+      // For message-based updates, allow only private chats
+      if (ctx.chat?.type === 'private') {
+        return next();
+      }
+      // Block everything else (like group messages)
+      return;
+    };
+  }
+}


### PR DESCRIPTION
As per title...

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced a new middleware that ensures the bot only responds to messages from private chats, blocking group and channel messages.
- **Chores**
  - Updated internal configuration to apply the new middleware globally across the bot.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->