### PR TITLE
hotfix: Update command detection to allow variations of '/start'

### DIFF
--- a/src/middleware/chat-type.middleware.ts
+++ b/src/middleware/chat-type.middleware.ts
@@ -59,7 +59,7 @@ export class PrivateChatMiddleware {
         typeof ctx.message === 'object' &&
         'text' in ctx.message &&
         typeof ctx.message.text === 'string' &&
-        (ctx.message.text === '/start' || ctx.message.text === '/start@MoltoBeneBot')
+        ctx.message.text.startsWith('/start')
       ) {
         await ctx.reply(`MoltoBene Bot here!
 Configuration looks perfect – I'm able to detect new users and greet them with their pizza names when I have admin access.


### PR DESCRIPTION
As per title....

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved recognition of the `/start` command in group chats, allowing detection of any message that begins with `/start`, not just exact matches.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->