### PR TITLE
feat: Implement `specific city` feature in admin broadcast flow

### DIFF
--- a/src/middleware/chat-type.middleware.ts
+++ b/src/middleware/chat-type.middleware.ts
@@ -14,8 +14,8 @@ export class PrivateChatMiddleware {
   use(): MiddlewareFn<Context> {
     return async (ctx, next) => {
       // Allow all non-message updates (inline queries, callback queries, etc.)
-      if (!ctx.chat && ctx.inlineQuery) {
-        return next(); // allow inline mode
+      if (!ctx.chat && (ctx.inlineQuery || ctx.callbackQuery)) {
+        return next();
       }
 
       // Allow "new_chat_members" in any chat
@@ -32,9 +32,9 @@ export class PrivateChatMiddleware {
       if (
         ctx.chat?.type !== 'private' &&
         ctx.message &&
-        typeof (ctx.message as any).text === 'string' &&
-        ((ctx.message as any).text === '/start' ||
-          (ctx.message as any).text === '/start@MoltoBeneBot')
+        'text' in ctx.message &&
+        typeof ctx.message.text === 'string' &&
+        (ctx.message.text === '/start' || ctx.message.text === '/start@MoltoBeneBot')
       ) {
         await ctx.reply(`MoltoBene Bot here!
 Configuration looks perfect – I’m able to detect new users and greet them with their pizza names when I have admin access.

--- a/src/modules/broadcast/broadcast.service.ts
+++ b/src/modules/broadcast/broadcast.service.ts
@@ -93,7 +93,7 @@ export class BroadcastService {
       this.commonService.setUserState(userId, session);
     }
 
-    if (!query || query === '<city_name>') {
+    if (!query || query === '') {
       await ctx.answerInlineQuery(
         [
           {
@@ -518,7 +518,7 @@ You can register via: \`\\{unlock\\_link\\}\`
                 [
                   {
                     text: '🔍 Search City',
-                    switch_inline_query_current_chat: '<city_name>',
+                    switch_inline_query_current_chat: '',
                   },
                 ],
               ],

--- a/src/modules/broadcast/broadcast.service.ts
+++ b/src/modules/broadcast/broadcast.service.ts
@@ -145,7 +145,7 @@ export class BroadcastService {
             [
               {
                 text: '✅ Confirm',
-                callback_data: `confirm_city_${city.group_id?.replace(/^-/, '')}`,
+                callback_data: `confirm_city_${city.group_id ? city.group_id.replace(/^-/, '') : 'confirm_city_none'}`,
               },
               {
                 text: '❌ Cancel',
@@ -509,8 +509,7 @@ You can register via: \`\\{unlock\\_link\\}\`
         await ctx.deleteMessage();
         await ctx.reply(
           `You can use the inline mode to search for a city and send a message directly\\.\n\n` +
-            `For example, type \`@MoltoBeneBot\` and the city name in the message field\\.`,
-
+            `For example, type \`@${this.escapeMarkdown(process.env.BOT_USERNAME || 'MoltoBeneBot')}\` and the city name in the message field\\.`,
           {
             parse_mode: 'MarkdownV2',
             reply_markup: {

--- a/src/modules/broadcast/broadcast.service.ts
+++ b/src/modules/broadcast/broadcast.service.ts
@@ -891,6 +891,13 @@ You can register via: \`\\{unlock\\_link\\}\`
 
       if (session.selectedCity) {
         // Send only to the selected city
+        if (!Array.isArray(session.selectedCity) || session.selectedCity.length === 0) {
+          await ctx.reply(this.escapeMarkdown('❌ Invalid selected city data.'), {
+            parse_mode: 'MarkdownV2',
+          });
+          return;
+        }
+
         const city = session.selectedCity[0];
 
         cityData = [

--- a/src/modules/broadcast/broadcast.service.ts
+++ b/src/modules/broadcast/broadcast.service.ts
@@ -83,7 +83,11 @@ export class BroadcastService {
     if (!userId) return ctx.answerInlineQuery([], { cache_time: 1 });
 
     // Fetch and cache all cities in session if not already cached
-    let allCities: ICity[] = (this.commonService.getUserState(userId)?.allCities as ICity[]) || [];
+    const currentSession = this.commonService.getUserState(userId);
+    let allCities: ICity[] =
+      currentSession?.allCities && Array.isArray(currentSession.allCities)
+        ? (currentSession.allCities as ICity[])
+        : [];
     if (allCities.length <= 0) {
       allCities = await this.cityService.getAllCities();
       const session: { allCities?: ICity[]; [key: string]: any } =

--- a/src/modules/broadcast/broadcast.service.ts
+++ b/src/modules/broadcast/broadcast.service.ts
@@ -289,7 +289,7 @@ You can register via: \`\\{unlock\\_link\\}\`
 
       await ctx.telegram.sendMessage(
         ctx.from.id,
-        `📢 You are assigned as admin to *Pizza DAO* for a specific city\\.\n\n` +
+        `📢 You are assigned as admin to *Pizza DAO*\\.\n\n` +
           `City Name: *${selectedCity[0]?.name}*\n\n` +
           `Send me one or multiple messages you want to include in the post\\. It can be anything — a text, photo, video, even a sticker\\.\n\n` +
           `You can use variables with below format within curly brackets\\.\n\n` +

--- a/src/modules/broadcast/broadcast.type.ts
+++ b/src/modules/broadcast/broadcast.type.ts
@@ -1,3 +1,5 @@
+import { ICity } from '../city/city.interface';
+
 export interface IUserAccess {
   role: string;
   city_data?: { city_name: string }[];
@@ -50,10 +52,15 @@ export interface IPostMessage {
   messageId?: number;
 }
 
+interface ISelectedCity extends ICity {
+  country_name: string;
+}
+
 export interface IBroadcastSession {
   step: 'awaiting_message' | 'creating_post' | 'idle';
   selectedAction?: string;
   messages: IPostMessage[];
   currentAction?: 'attach_media' | 'add_url_buttons';
   currentMessageIndex?: number;
+  selectedCity?: ISelectedCity[];
 }

--- a/src/modules/city/city.interface.ts
+++ b/src/modules/city/city.interface.ts
@@ -2,6 +2,7 @@ export interface ICity {
   id: string;
   name: string;
   country_id: string;
+  group_id?: string;
   telegram_link?: string;
 }
 

--- a/src/modules/city/city.service.ts
+++ b/src/modules/city/city.service.ts
@@ -6,6 +6,10 @@ import { ICity } from './city.interface';
 export class CityService {
   constructor(private readonly knexService: KnexService) {}
 
+  async getAllCities(): Promise<ICity[]> {
+    return this.knexService.knex('city').select('id', 'name', 'group_id', 'country_id');
+  }
+
   async getCitiesByCountry(countryId: string): Promise<ICity[]> {
     return this.knexService
       .knex('city')


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added inline city search and selection for targeted message broadcasts, enabling users to search and select specific cities.
  - Introduced a "Specific City" option in the broadcast menu for precise audience targeting.
- **Improvements**
  - Enhanced broadcast creation workflow with clearer prompts and updated message previews.
  - Expanded city data to include optional Telegram group IDs.
  - Allowed callback queries alongside inline queries when no chat context is present for better interaction handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->