### PR TITLE
fix: Prevent handling new chat members if they are bots

### DIFF
--- a/src/modules/welcome/welcome.service.ts
+++ b/src/modules/welcome/welcome.service.ts
@@ -325,7 +325,12 @@ export class WelcomeService {
   async handleNewMember(ctx: Context) {
     const { message } = ctx;
 
-    if (!message || !('new_chat_members' in message) || !('chat' in message)) {
+    if (
+      !message ||
+      !('new_chat_members' in message) ||
+      !('chat' in message) ||
+      message.new_chat_members.some((member) => member.is_bot)
+    ) {
       return;
     }
 


### PR DESCRIPTION
Fixes #37 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved handling of new chat members by preventing the welcome process from triggering when bots join the chat.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->