### PR TITLE
Update e2e bootstrap to use createAppModule

### DIFF
--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -69,3 +69,27 @@ config();
   providers: [AppService],
 })
 export class AppModule {}
+
+export function createAppModule(
+  bots: Array<{ id: string; name: string; bot_token: string; is_active: boolean }>,
+) {
+  const token = bots && bots.length > 0 ? bots[0].bot_token : '';
+  process.env.TELEGRAM_BOT_TOKEN = token;
+
+  @Module({
+    imports: [
+      ConfigModule.forRoot({
+        isGlobal: true,
+        load: [() => ({ TELEGRAM_BOT_TOKEN: token })],
+      }),
+      TelegrafModule.forRoot({
+        token,
+      }),
+    ],
+    controllers: [AppController],
+    providers: [AppService],
+  })
+  class DynamicAppModule {}
+
+  return DynamicAppModule;
+}

--- a/test/app.e2e-spec.ts
+++ b/test/app.e2e-spec.ts
@@ -1,7 +1,7 @@
 import { Test, TestingModule } from '@nestjs/testing';
 import { INestApplication } from '@nestjs/common';
 import * as request from 'supertest';
-import { AppModule } from './../src/app.module';
+import { createAppModule } from './../src/app.module';
 import { getBotToken } from 'nestjs-telegraf';
 import { ConfigModule } from '@nestjs/config';
 import * as express from 'express';
@@ -39,7 +39,9 @@ describe('AppController (e2e)', () => {
         ConfigModule.forRoot({
           isGlobal: true,
         }),
-        AppModule,
+        createAppModule([
+          { id: 'test', name: 'test', bot_token: 'token', is_active: true },
+        ]),
       ],
     })
       .overrideProvider(getBotToken())

--- a/test/jest-e2e.json
+++ b/test/jest-e2e.json
@@ -5,5 +5,8 @@
   "testRegex": ".e2e-spec.ts$",
   "transform": {
     "^.+\\.(t|j)s$": "ts-jest"
+  },
+  "moduleNameMapper": {
+    "^src/(.*)$": "<rootDir>/../src/$1"
   }
 }


### PR DESCRIPTION
## Summary
- create a `createAppModule` factory in `src/app.module.ts`
- configure jest e2e to resolve `src/*` imports
- update e2e test to bootstrap with `createAppModule`

## Testing
- `npm run test:e2e`

------
https://chatgpt.com/codex/tasks/task_e_685fbd025440832cb8a937b11319c51e

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced flexibility by allowing dynamic configuration of the application module based on provided bot tokens.

* **Tests**
  * Updated end-to-end tests to support dynamic module initialization with custom bot configurations.
  * Improved test configuration to ensure correct resolution of source modules during testing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->