### PR TITLE
Implement basic multi-tenant mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ This bot serves as the registration and management system for PizzaDAO's telegra
   - Automated welcome messages
   - User permission management
   - Multi-city group support
+  - Multi-tenant support with separate bot tokens
   - Message cleanup and organization
 
 ## 🛠 Tech Stack
@@ -68,8 +69,18 @@ docker-compose up -d
 5. Run database migrations:
 ```bash
 npm run migrate
-npm run fixtures
+ npm run fixtures
 ```
+
+### Register Tenants
+
+To onboard a new client, register a tenant with its Telegram bot token:
+
+```bash
+npm run register:tenant -- <TENANT_NAME> <BOT_TOKEN> [BOT_USERNAME]
+```
+
+Run migrations and fixtures after adding tenants to ensure the table exists.
 
 6. Sync unlock events:
 ```bash

--- a/package.json
+++ b/package.json
@@ -27,7 +27,8 @@
     "test:watch": "jest --watch",
     "test:cov": "jest --coverage",
     "test:debug": "node --inspect-brk -r tsconfig-paths/register -r ts-node/register node_modules/.bin/jest --runInBand",
-    "test:e2e": "jest --config ./test/jest-e2e.json"
+    "test:e2e": "jest --config ./test/jest-e2e.json",
+    "register:tenant": "ts-node scripts/registerTenant.ts"
   },
   "dependencies": {
     "@nestjs/common": "^11.0.1",

--- a/scripts/registerTenant.ts
+++ b/scripts/registerTenant.ts
@@ -1,0 +1,28 @@
+import { knex as createKnex } from 'knex';
+import knexConfig from '../knexfile';
+import { ITenant } from '../src/modules/tenant/tenant.interface';
+
+async function main() {
+  const args = process.argv.slice(2);
+  const [name, token, username] = args;
+  if (!name || !token) {
+    console.error('Usage: ts-node registerTenant.ts <name> <bot_token> [bot_username]');
+    process.exit(1);
+  }
+
+  const env = process.env.NODE_ENV || 'development';
+  const knex = createKnex((knexConfig as Record<string, any>)[env]);
+
+  try {
+    const [tenant] = await knex<ITenant>('tenant')
+      .insert({ name, bot_token: token, bot_username: username, is_active: true })
+      .returning('*');
+    console.log('Tenant registered:', tenant);
+  } catch (err) {
+    console.error('Failed to register tenant:', err);
+  } finally {
+    await knex.destroy();
+  }
+}
+
+main();

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -3,9 +3,9 @@
  * @module app.module
  */
 
-import { Module } from '@nestjs/common';
+import { Module, Type } from '@nestjs/common';
 import { TelegrafModule } from 'nestjs-telegraf';
-import { ConfigModule, ConfigService } from '@nestjs/config';
+import { ConfigModule } from '@nestjs/config';
 import { config } from 'dotenv';
 import { AppService } from './app.service';
 import { AppController } from './app.controller';
@@ -18,54 +18,48 @@ import { CommonModule } from './modules/common/common.module';
 import { PrivateChatMiddleware } from './middleware/chat-type.middleware';
 import { BroadcastModule } from './modules/broadcast/broadcast.module';
 import { EventDetailModule } from './modules/event-detail/event-detail.module';
+import { ITenant } from './modules/tenant/tenant.interface';
+import { TenantModule } from './modules/tenant/tenant.module';
 
 // Load environment variables
 config();
 
-/**
- * Root module of the application that configures and bootstraps all required modules
- * @class AppModule
- * @description Configures the main application module with all necessary dependencies,
- * including the Telegram bot, database connection, and various feature modules.
- */
-@Module({
-  imports: [
-    ConfigModule.forRoot(),
-    TelegrafModule.forRootAsync({
-      imports: [ConfigModule],
-      useFactory: (configService: ConfigService) => {
-        const token = configService.get<string>('TELEGRAM_BOT_TOKEN');
-        if (!token) {
-          throw new Error('TELEGRAM_BOT_TOKEN is not defined in the environment variables');
-        }
-        return {
-          token,
-          launchOptions:
-            process.env.ENABLE_WEBHOOK === 'true'
-              ? {
-                  webhook: {
-                    domain: configService.get<string>('WEBHOOK_DOMAIN') || '',
-                    path: '/webhook',
-                  },
-                }
-              : {},
-          middlewares: [new PrivateChatMiddleware().use()],
-        };
-      },
-      inject: [ConfigService],
+export function createAppModule(tenants: ITenant[]): Type<any> {
+  const botModules = tenants.map((tenant) =>
+    TelegrafModule.forRoot({
+      token: tenant.bot_token,
+      botName: tenant.name,
+      launchOptions:
+        process.env.ENABLE_WEBHOOK === 'true'
+          ? {
+              webhook: {
+                domain: process.env.WEBHOOK_DOMAIN || '',
+                path: '/webhook',
+              },
+            }
+          : {},
+      middlewares: [new PrivateChatMiddleware().use()],
     }),
+  );
 
-    UserModule,
-    WelcomeModule,
-    BroadcastModule,
-    CommonModule,
-    KnexModule,
-    CountryModule,
-    CityModule,
-    EventDetailModule,
-  ],
+  @Module({
+    imports: [
+      ConfigModule.forRoot(),
+      ...botModules,
+      TenantModule,
+      UserModule,
+      WelcomeModule,
+      BroadcastModule,
+      CommonModule,
+      KnexModule,
+      CountryModule,
+      CityModule,
+      EventDetailModule,
+    ],
+    controllers: [AppController],
+    providers: [AppService],
+  })
+  class AppModule {}
 
-  controllers: [AppController],
-  providers: [AppService],
-})
-export class AppModule {}
+  return AppModule;
+}

--- a/src/fixtures/10_tenant-fixtures.ts
+++ b/src/fixtures/10_tenant-fixtures.ts
@@ -1,0 +1,13 @@
+import type { Knex } from 'knex';
+
+export async function seed(knex: Knex): Promise<void> {
+  await knex('tenant').del();
+  await knex('tenant').insert([
+    {
+      name: 'PizzaDAO',
+      bot_token: 'YOUR_PIZZADAO_BOT_TOKEN',
+      bot_username: 'pizza_bot',
+      is_active: true,
+    },
+  ]);
+}

--- a/src/main.ts
+++ b/src/main.ts
@@ -4,10 +4,13 @@
  */
 
 import { NestFactory } from '@nestjs/core';
-import { AppModule } from './app.module';
 import { getBotToken } from 'nestjs-telegraf';
 import { Telegraf } from 'telegraf';
 import { json } from 'express';
+import { knex as createKnex } from 'knex';
+import knexConfig from '../knexfile';
+import { ITenant } from './modules/tenant/tenant.interface';
+import { createAppModule } from './app.module';
 
 /**
  * Bootstraps the NestJS application and configures the Telegram bot
@@ -17,19 +20,37 @@ import { json } from 'express';
  * @throws {Error} If there's an error during application bootstrap
  */
 async function bootstrap() {
+  const NODE_ENV = process.env.NODE_ENV || 'development';
+  const knex = createKnex((knexConfig as Record<string, any>)[NODE_ENV]);
+
+  let tenants: ITenant[] = [];
+  try {
+    tenants = await knex<ITenant>('tenant').where({ is_active: true });
+  } catch (error) {
+    console.error('Failed to load tenants:', error);
+  } finally {
+    await knex.destroy();
+  }
+
+  if (tenants.length === 0) {
+    const envToken = process.env.TELEGRAM_BOT_TOKEN;
+    if (!envToken) {
+      throw new Error('No tenants found and TELEGRAM_BOT_TOKEN is not set');
+    }
+    tenants = [{ id: 'env', name: 'default', bot_token: envToken, is_active: true } as ITenant];
+  }
+
+  const AppModule = createAppModule(tenants);
   const app = await NestFactory.create(AppModule);
 
-  // Get the bot instance
-  const bot = app.get<Telegraf>(getBotToken());
+  const bots = tenants.map((t) => app.get<Telegraf>(getBotToken(t.name)));
 
   app.use(json());
 
-  // Connect the webhook middleware
   if (process.env.ENABLE_WEBHOOK === 'true') {
-    app.use(bot.webhookCallback('/webhook'));
+    bots.forEach((bot) => app.use(bot.webhookCallback('/webhook')));
   }
 
-  // Start the NestJS application
   const PORT = process.env.PORT || 3000;
   await app.listen(PORT, () => {
     console.log(`Application is running on port ${PORT}`);

--- a/src/migrations/20250628100000_create_tenant_table.ts
+++ b/src/migrations/20250628100000_create_tenant_table.ts
@@ -1,0 +1,20 @@
+import type { Knex } from 'knex';
+
+const tableName = 'tenant';
+
+export async function up(knex: Knex): Promise<void> {
+  await knex.raw('CREATE EXTENSION IF NOT EXISTS "uuid-ossp";');
+
+  await knex.schema.createTable(tableName, (table) => {
+    table.uuid('id').primary().defaultTo(knex.raw('uuid_generate_v4()'));
+    table.string('name').notNullable().unique();
+    table.string('bot_token').notNullable();
+    table.string('bot_username');
+    table.boolean('is_active').notNullable().defaultTo(true);
+    table.timestamps(true, true);
+  });
+}
+
+export async function down(knex: Knex): Promise<void> {
+  await knex.schema.dropTable(tableName);
+}

--- a/src/modules/tenant/tenant.interface.ts
+++ b/src/modules/tenant/tenant.interface.ts
@@ -1,0 +1,9 @@
+export interface ITenant {
+  id: string;
+  name: string;
+  bot_token: string;
+  bot_username?: string;
+  is_active: boolean;
+  created_at?: Date;
+  updated_at?: Date;
+}

--- a/src/modules/tenant/tenant.module.ts
+++ b/src/modules/tenant/tenant.module.ts
@@ -1,0 +1,11 @@
+import { Global, Module } from '@nestjs/common';
+import { TenantService } from './tenant.service';
+import { KnexModule } from '../knex/knex.module';
+
+@Global()
+@Module({
+  imports: [KnexModule],
+  providers: [TenantService],
+  exports: [TenantService],
+})
+export class TenantModule {}

--- a/src/modules/tenant/tenant.service.ts
+++ b/src/modules/tenant/tenant.service.ts
@@ -1,0 +1,17 @@
+import { Injectable } from '@nestjs/common';
+import { KnexService } from '../knex/knex.service';
+import { ITenant } from './tenant.interface';
+
+@Injectable()
+export class TenantService {
+  constructor(private readonly knexService: KnexService) {}
+
+  async getActiveTenants(): Promise<ITenant[]> {
+    return this.knexService.knex<ITenant>('tenant').where({ is_active: true }).select('*');
+  }
+
+  async createTenant(tenant: Omit<ITenant, 'id' | 'created_at' | 'updated_at'>): Promise<ITenant> {
+    const [created] = await this.knexService.knex<ITenant>('tenant').insert(tenant).returning('*');
+    return created;
+  }
+}


### PR DESCRIPTION
## Summary
- add tenant migration and seed
- create tenant module and service
- enable dynamic bot creation for tenants
- add CLI to register new tenants
- document multi-tenant usage

## Testing
- `npm run lint`
- `npm test -- --passWithNoTests`


------
https://chatgpt.com/codex/tasks/task_e_685faad8ceec832c84fb6cc958e62b6f

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced multi-tenant support, allowing management of multiple Telegram bots with separate tokens.
  * Added a new command-line tool for registering tenants (clients) with their bot tokens.
  * Added a database migration and fixtures for tenant management.
  * New section in documentation describing tenant registration and onboarding.

* **Documentation**
  * Updated README to reflect multi-tenant capabilities and provide installation and onboarding instructions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->