### PR TITLE
suppli-58533: forward PDF receipts to rsvpizza (accept application/pdf docs + mimeType)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -16,3 +16,13 @@ EVENT_IMAGE_URL=
 
 LOG_GROUP_ID=
 LOG_THREAD_ID=
+
+# rsvpizza integration (provola-58505)
+# Gates GET /city/groups (sent by rsvpizza in the x-api-key header). Must match
+# the value rsvpizza uses for its moltobene sync.
+RSVPIZZA_API_KEY=
+# Base URL of the rsvpizza backend used for the host-link callback.
+RSVPIZZA_BASE_URL=https://api.rsv.pizza
+# Shared secret sent as x-api-key to rsvpizza's /api/telegram/link-host callback.
+# Must match the value rsvpizza expects.
+TELEGRAM_LINK_CALLBACK_SECRET=

--- a/railway.json
+++ b/railway.json
@@ -1,6 +1,0 @@
-{
-  "$schema": "https://railway.com/railway.schema.json",
-  "deploy": {
-    "preDeployCommand": "npm run migrate"
-  }
-}

--- a/railway.json
+++ b/railway.json
@@ -1,0 +1,6 @@
+{
+  "$schema": "https://railway.com/railway.schema.json",
+  "deploy": {
+    "preDeployCommand": "npm run migrate"
+  }
+}

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -18,6 +18,8 @@ import { CommonModule } from './modules/common/common.module';
 import { PrivateChatMiddleware } from './middleware/chat-type.middleware';
 import { BroadcastModule } from './modules/broadcast/broadcast.module';
 import { EventDetailModule } from './modules/event-detail/event-detail.module';
+import { CapturedGroupModule } from './modules/captured-group/captured-group.module';
+import { CapturedGroupService } from './modules/captured-group/captured-group.service';
 
 // Load environment variables
 config();
@@ -32,8 +34,8 @@ config();
   imports: [
     ConfigModule.forRoot(),
     TelegrafModule.forRootAsync({
-      imports: [ConfigModule],
-      useFactory: (configService: ConfigService) => {
+      imports: [ConfigModule, CapturedGroupModule],
+      useFactory: (configService: ConfigService, capturedGroupService: CapturedGroupService) => {
         const token = configService.get<string>('TELEGRAM_BOT_TOKEN');
         if (!token) {
           throw new Error('TELEGRAM_BOT_TOKEN is not defined in the environment variables');
@@ -49,10 +51,12 @@ config();
                   },
                 }
               : {},
-          middlewares: [new PrivateChatMiddleware().use()],
+          // Passive group-capture runs FIRST (always calls next()), then the
+          // existing private-chat gate, then all @On/@Command/@Start handlers.
+          middlewares: [capturedGroupService.middleware(), new PrivateChatMiddleware().use()],
         };
       },
-      inject: [ConfigService],
+      inject: [ConfigService, CapturedGroupService],
     }),
 
     UserModule,
@@ -63,6 +67,7 @@ config();
     CountryModule,
     CityModule,
     EventDetailModule,
+    CapturedGroupModule,
   ],
 
   controllers: [AppController],

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -20,6 +20,7 @@ import { BroadcastModule } from './modules/broadcast/broadcast.module';
 import { EventDetailModule } from './modules/event-detail/event-detail.module';
 import { CapturedGroupModule } from './modules/captured-group/captured-group.module';
 import { CapturedGroupService } from './modules/captured-group/captured-group.service';
+import { HostInboundModule } from './modules/host-inbound/host-inbound.module';
 
 // Load environment variables
 config();
@@ -68,6 +69,7 @@ config();
     CityModule,
     EventDetailModule,
     CapturedGroupModule,
+    HostInboundModule,
   ],
 
   controllers: [AppController],

--- a/src/fixtures/3_city-fixtures.ts
+++ b/src/fixtures/3_city-fixtures.ts
@@ -25,7 +25,7 @@ export async function seed(knex: Knex): Promise<void> {
 
     // Abidjan
     {
-      name: 'Ivory Coast',
+      name: 'Abidjan',
       country_id: countryMap['Abidjan'],
       group_id: -4743402147,
       telegram_link: 'https://t.me/+JWOR_uVzisw3NWZk',
@@ -38,7 +38,7 @@ export async function seed(knex: Knex): Promise<void> {
     //   telegram_link: null,
     // },
     {
-      name: 'Mazar-i-Sharif',
+      name: 'Mazar-e-Sharif',
       country_id: countryMap['Afghanistan'],
       group_id: -1002068411229,
       telegram_link: 'https://t.me/+Q8ChxoCFslAzMzFh',
@@ -71,7 +71,7 @@ export async function seed(knex: Knex): Promise<void> {
       telegram_link: 'https://t.me/+oK58UluVeuFhZjgx',
     },
     {
-      name: 'Entre Rios',
+      name: 'Gualeguaychú Entre Ríos',
       country_id: countryMap['Argentina'],
       group_id: -4756690061,
       telegram_link: 'https://t.me/+kK8avIREGho1MWQ5',
@@ -256,7 +256,7 @@ export async function seed(knex: Knex): Promise<void> {
       telegram_link: 'https://t.me/+wGJjX7piV4gzM2Nh',
     },
     {
-      name: 'Buzios',
+      name: 'Búzios',
       country_id: countryMap['Brazil'],
       group_id: -4687749004,
       telegram_link: 'https://t.me/+WlqFgKPYcjJhMTFh',
@@ -560,7 +560,7 @@ export async function seed(knex: Knex): Promise<void> {
       telegram_link: 'https://t.me/+5jv65SAxeu5jYzhh',
     },
     {
-      name: 'Cartagena',
+      name: 'Cartagena de Indias',
       country_id: countryMap['Colombia'],
       group_id: -1002182199547,
       telegram_link: 'https://t.me/+KKC3CCLGYX03Y2M5',
@@ -1562,7 +1562,7 @@ export async function seed(knex: Knex): Promise<void> {
       telegram_link: 'https://t.me/+Qty6hBmar21kNmIx',
     },
     {
-      name: 'Mérida',
+      name: 'Merida',
       country_id: countryMap['Mexico'],
       group_id: -1002355994780,
       telegram_link: 'https://t.me/+s6gJ8AnpYx0zYjgx',
@@ -1644,7 +1644,7 @@ export async function seed(knex: Knex): Promise<void> {
       telegram_link: 'https://t.me/+bZT_3pcvEWtiOTkx',
     },
     {
-      name: 'Marrakesh',
+      name: 'Marrakech',
       country_id: countryMap['Morocco'],
       group_id: -1002371010885,
       telegram_link: 'https://t.me/+ACv3eoIimYIzYzYx',
@@ -1820,7 +1820,7 @@ export async function seed(knex: Knex): Promise<void> {
       telegram_link: 'https://t.me/+nPtJoG7-JMM1Yjgx',
     },
     {
-      name: 'Enugu',
+      name: 'Enugu City',
       country_id: countryMap['Nigeria'],
       group_id: -1001886670148,
       telegram_link: 'https://t.me/+FN-o8aMZhjJmOTcx',
@@ -1838,7 +1838,7 @@ export async function seed(knex: Knex): Promise<void> {
       telegram_link: 'https://t.me/+CKxe32vDKyVkMDcx',
     },
     {
-      name: 'Keffi, Nasarawa state',
+      name: 'Keffi',
       country_id: countryMap['Nigeria'],
       group_id: -4712909471,
       telegram_link: 'https://t.me/+mM8wP6FZZFZmOWIx',
@@ -1856,7 +1856,7 @@ export async function seed(knex: Knex): Promise<void> {
       telegram_link: 'https://t.me/+zOdAqKYVfYZjYTMx',
     },
     {
-      name: 'Lokoja',
+      name: 'Lokoja City',
       country_id: countryMap['Nigeria'],
       group_id: -4706102647,
       telegram_link: 'https://t.me/+Ox5H1huZpjdiMjUx',
@@ -1938,14 +1938,14 @@ export async function seed(knex: Knex): Promise<void> {
     },
     // Panama
     {
-      name: 'Ciudad de Panama',
+      name: 'Panama City',
       country_id: countryMap['Panama'],
       group_id: -4750445540,
       telegram_link: 'https://t.me/+hhdQmJ8qtiE5ZTE5',
     },
     // Peru
     {
-      name: 'Cusco',
+      name: 'Cuzco',
       country_id: countryMap['Peru'],
       group_id: -4121520945,
       telegram_link: 'https://t.me/+M1MwSfps-WU5MjMx',
@@ -2186,7 +2186,7 @@ export async function seed(knex: Knex): Promise<void> {
     },
     // Slovenia
     {
-      name: 'Llubjana',
+      name: 'Ljubljana',
       country_id: countryMap['Slovenia'],
       group_id: -1002477120506,
       telegram_link: 'https://t.me/+F7IlQDeSEgU4NTBh',
@@ -2224,7 +2224,7 @@ export async function seed(knex: Knex): Promise<void> {
       telegram_link: 'https://t.me/+3RnvXOt6f4szMGEx',
     },
     {
-      name: 'Gran Canaria',
+      name: 'Las Palmas de Gran Canaria',
       country_id: countryMap['Spain'],
       group_id: -4737102391,
       telegram_link: 'https://t.me/+o0uLz-mAh0g2NTMx',
@@ -2242,7 +2242,7 @@ export async function seed(knex: Knex): Promise<void> {
       telegram_link: 'https://t.me/+6CS2vjriPNJhMDQx',
     },
     {
-      name: 'Malaga',
+      name: 'Málaga',
       country_id: countryMap['Spain'],
       group_id: -1002689164265,
       telegram_link: 'https://t.me/+Br0YD2x4qFAzOWQx',
@@ -2448,7 +2448,7 @@ export async function seed(knex: Knex): Promise<void> {
       telegram_link: 'https://t.me/+5-RwsDjsWkY2MDUx',
     },
     {
-      name: 'Montgomery',
+      name: 'Montgomery, AL',
       country_id: countryMap['USA AL'],
       group_id: -1002622509517,
       telegram_link: 'https://t.me/+2Uq2tmJtvuYwNzQx',
@@ -2798,7 +2798,7 @@ export async function seed(knex: Knex): Promise<void> {
     },
     // USA NJ
     {
-      name: 'Atlantic City, NJ',
+      name: 'Atlantic City',
       country_id: countryMap['USA NJ'],
       group_id: -4154984838,
       telegram_link: 'https://t.me/+rGtfdMLxF_4zOTZh',
@@ -2876,7 +2876,7 @@ export async function seed(knex: Knex): Promise<void> {
     },
     // USA OR
     {
-      name: 'Portland OR',
+      name: 'Portland Oregon',
       country_id: countryMap['USA OR'],
       group_id: -1001825156130,
       telegram_link: 'https://t.me/+wjMKnf-PjZliZDFh',
@@ -2961,7 +2961,7 @@ export async function seed(knex: Knex): Promise<void> {
     },
     // USA VA
     {
-      name: 'Richmond',
+      name: 'Richmond Virginia',
       country_id: countryMap['USA VA'],
       group_id: -4623578295,
       telegram_link: 'https://t.me/+vKktl1TNLJBlZmYx',

--- a/src/middleware/chat-type.middleware.ts
+++ b/src/middleware/chat-type.middleware.ts
@@ -52,6 +52,17 @@ export class PrivateChatMiddleware {
         return next();
       }
 
+      // Allow /chatid in any chat type
+      if (
+        ctx.message &&
+        typeof ctx.message === 'object' &&
+        'text' in ctx.message &&
+        typeof ctx.message.text === 'string' &&
+        ctx.message.text.startsWith('/chatid')
+      ) {
+        return next();
+      }
+
       // Send a message to /start command in groups
       if (
         ctx.chat?.type !== 'private' &&

--- a/src/migrations/20260607041044_create_telegram_group_captures_table.ts
+++ b/src/migrations/20260607041044_create_telegram_group_captures_table.ts
@@ -1,0 +1,30 @@
+import type { Knex } from 'knex';
+
+const tableName = 'telegram_group_captures';
+
+/**
+ * Creates the standalone `telegram_group_captures` table.
+ *
+ * This table passively records every Telegram group/supergroup the bot is a
+ * member of, keyed by `chat_id`. Unlike the `city` table it has NO foreign keys
+ * and no required city/country mapping, so it can store groups (e.g. "goshen")
+ * that are not yet linked to a known city. It is exposed read-only to rsvpizza
+ * via `GET /captured-groups` so rsvpizza can match captured groups against its
+ * own event data.
+ */
+export async function up(knex: Knex): Promise<void> {
+  await knex.schema.createTable(tableName, (table) => {
+    table.uuid('id').primary().defaultTo(knex.raw('uuid_generate_v4()'));
+    table.string('chat_id').notNullable().unique();
+    table.string('title');
+    table.string('chat_type');
+    table.timestamp('first_seen_at', { useTz: true }).notNullable().defaultTo(knex.fn.now());
+    table.timestamp('last_seen_at', { useTz: true }).notNullable().defaultTo(knex.fn.now());
+
+    table.index('chat_id', 'idx_telegram_group_captures_chat_id');
+  });
+}
+
+export async function down(knex: Knex): Promise<void> {
+  await knex.schema.dropTableIfExists(tableName);
+}

--- a/src/modules/captured-group/captured-group.controller.ts
+++ b/src/modules/captured-group/captured-group.controller.ts
@@ -1,0 +1,99 @@
+/**
+ * @fileoverview Controller exposing passively captured Telegram groups to rsvpizza
+ * @module captured-group.controller
+ */
+
+import {
+  Controller,
+  Get,
+  UseGuards,
+  UnauthorizedException,
+  Injectable,
+  CanActivate,
+  ExecutionContext,
+} from '@nestjs/common';
+import { Request } from 'express';
+import { CapturedGroupService } from './captured-group.service';
+
+/**
+ * Guard for protecting the rsvpizza captured-groups export route with API key auth.
+ * @class RsvpizzaApiKeyGuard
+ * @implements {CanActivate}
+ * @description Mirrors the guard used by the `/city/groups` export: authorizes
+ * against `RSVPIZZA_API_KEY` (and still accepts the shared `USER_API_KEY` for
+ * backwards-compatible internal callers) via the `x-api-key` header.
+ */
+@Injectable()
+class RsvpizzaApiKeyGuard implements CanActivate {
+  /**
+   * Validates the API key from request headers
+   * @param {ExecutionContext} context - The execution context
+   * @returns {boolean} True if the API key is valid
+   * @throws {UnauthorizedException} If the API key is invalid or missing
+   */
+  canActivate(context: ExecutionContext): boolean {
+    const request: Request = context.switchToHttp().getRequest<Request>();
+    const apiKey = request.headers['x-api-key'];
+    if (
+      apiKey &&
+      (apiKey === process.env.RSVPIZZA_API_KEY || apiKey === process.env.USER_API_KEY)
+    ) {
+      return true;
+    }
+    throw new UnauthorizedException('Invalid API key');
+  }
+}
+
+/**
+ * Shape of a single captured group returned by the `/captured-groups` export
+ * @interface ICapturedGroupExport
+ */
+interface ICapturedGroupExport {
+  chatId: string;
+  title: string;
+  chatType: string;
+  lastSeenAt: string;
+}
+
+/**
+ * Normalizes a timestamp value (Date from pg, or already a string) to an ISO string.
+ * @param {unknown} value - The raw timestamp value
+ * @returns {string} ISO 8601 string, or empty string when absent
+ */
+function toIsoString(value: unknown): string {
+  if (value instanceof Date) {
+    return value.toISOString();
+  }
+  return value != null ? String(value) : '';
+}
+
+/**
+ * Controller exposing the passively captured Telegram groups.
+ * @class CapturedGroupController
+ * @description Provides a read-only export of every group/supergroup the bot is
+ * in, for rsvpizza to match against its own event data.
+ */
+@Controller('captured-groups')
+export class CapturedGroupController {
+  constructor(private readonly capturedGroupService: CapturedGroupService) {}
+
+  /**
+   * Exports every passively captured Telegram group.
+   * @returns {Promise<{ groups: ICapturedGroupExport[] }>} Exported groups
+   * @protected Requires valid `RSVPIZZA_API_KEY` (or `USER_API_KEY`) in `x-api-key`
+   */
+  @UseGuards(RsvpizzaApiKeyGuard)
+  @Get()
+  async getCapturedGroups(): Promise<{ groups: ICapturedGroupExport[] }> {
+    const captures = await this.capturedGroupService.getAllCapturedGroups();
+
+    const groups: ICapturedGroupExport[] = captures.map((capture) => ({
+      chatId: capture.chat_id ?? '',
+      title: capture.title ?? '',
+      chatType: capture.chat_type ?? '',
+      lastSeenAt: toIsoString(capture.last_seen_at),
+    }));
+
+    return { groups };
+  }
+}

--- a/src/modules/captured-group/captured-group.interface.ts
+++ b/src/modules/captured-group/captured-group.interface.ts
@@ -1,0 +1,51 @@
+/**
+ * @fileoverview Interfaces for the captured-group module
+ * @module captured-group.interface
+ */
+
+/**
+ * Interface representing a passively captured Telegram group row
+ * @interface ICapturedGroup
+ * @description Mirrors a row of the `telegram_group_captures` table. Records
+ * every group/supergroup the bot is a member of, independent of whether the
+ * group is mapped to a known city.
+ */
+export interface ICapturedGroup {
+  /**
+   * Unique identifier for the capture row
+   * @type {string}
+   */
+  id: string;
+
+  /**
+   * Telegram chat id of the group (stored as string to preserve precision)
+   * @type {string}
+   */
+  chat_id: string;
+
+  /**
+   * Title of the group at the time it was last seen
+   * @type {string | null}
+   * @optional
+   */
+  title?: string | null;
+
+  /**
+   * Telegram chat type, e.g. `group` or `supergroup`
+   * @type {string | null}
+   * @optional
+   */
+  chat_type?: string | null;
+
+  /**
+   * Timestamp the group was first recorded
+   * @type {string}
+   */
+  first_seen_at: string;
+
+  /**
+   * Timestamp the group was last seen
+   * @type {string}
+   */
+  last_seen_at: string;
+}

--- a/src/modules/captured-group/captured-group.module.ts
+++ b/src/modules/captured-group/captured-group.module.ts
@@ -1,0 +1,24 @@
+/**
+ * @fileoverview Module for passive Telegram group capture + rsvpizza export
+ * @module captured-group.module
+ */
+
+import { Module } from '@nestjs/common';
+import { CapturedGroupService } from './captured-group.service';
+import { CapturedGroupController } from './captured-group.controller';
+import { KnexModule } from '../knex/knex.module';
+
+/**
+ * Module wiring the passive group-capture service + export endpoint.
+ * @class CapturedGroupModule
+ * @description Exposes {@link CapturedGroupService} so its capture middleware can
+ * be plugged into the TelegrafModule, and registers the `/captured-groups`
+ * export controller.
+ */
+@Module({
+  imports: [KnexModule],
+  providers: [CapturedGroupService],
+  controllers: [CapturedGroupController],
+  exports: [CapturedGroupService],
+})
+export class CapturedGroupModule {}

--- a/src/modules/captured-group/captured-group.service.ts
+++ b/src/modules/captured-group/captured-group.service.ts
@@ -1,0 +1,134 @@
+/**
+ * @fileoverview Service for passively capturing every Telegram group the bot is in
+ * @module captured-group.service
+ */
+
+import { Injectable, Logger } from '@nestjs/common';
+import { Context, MiddlewareFn } from 'telegraf';
+import { KnexService } from '../knex/knex.service';
+import { ICapturedGroup } from './captured-group.interface';
+
+const TABLE_NAME = 'telegram_group_captures';
+
+/**
+ * Telegram chat types that represent a group we want to record
+ */
+const GROUP_CHAT_TYPES = new Set(['group', 'supergroup']);
+
+/**
+ * Service that passively records the `chat_id` of every group/supergroup the bot
+ * receives an update from.
+ *
+ * @class CapturedGroupService
+ * @description The bot polls `getUpdates` with privacy OFF, so it already
+ * receives every group message — this service simply records the group's
+ * `chat_id` into the standalone `telegram_group_captures` table. It is wired in
+ * as a global Telegraf middleware (via {@link middleware}) so it runs IN ADDITION
+ * to — and ahead of — all existing `@On`/`@Command`/`@Start` handlers, and always
+ * calls `next()` so it never disrupts the existing flow.
+ *
+ * To avoid a write-firehose it keeps an in-memory {@link seenChatIds} set: once a
+ * `chat_id` has been recorded in this process it is never written again, so the
+ * steady state is zero DB hits.
+ */
+@Injectable()
+export class CapturedGroupService {
+  private readonly logger = new Logger(CapturedGroupService.name);
+
+  /**
+   * In-memory guard of chat_ids already recorded this process lifetime.
+   * Prevents a DB write on every single group message.
+   * @private
+   */
+  private readonly seenChatIds = new Set<string>();
+
+  constructor(private readonly knexService: KnexService) {}
+
+  /**
+   * Returns a Telegraf middleware that passively captures group chat ids.
+   *
+   * Registered via the TelegrafModule `middlewares` option so it is applied at
+   * bot-construction time, guaranteeing it runs before any `@On('message')`
+   * terminal handlers. It is fully fire-and-forget: any error is swallowed and
+   * it always calls `next()`.
+   *
+   * @returns {MiddlewareFn<Context>} The capture middleware
+   */
+  middleware(): MiddlewareFn<Context> {
+    return async (ctx, next) => {
+      try {
+        this.captureFromContext(ctx);
+      } catch (error) {
+        // Never let capture break the existing handler chain.
+        this.logger.warn(`Passive group capture failed: ${String(error)}`);
+      }
+      return next();
+    };
+  }
+
+  /**
+   * Extracts the group chat from any update type and records it if new.
+   * @param {Context} ctx - The Telegraf context
+   * @private
+   */
+  private captureFromContext(ctx: Context): void {
+    const chat = ctx.chat;
+    if (!chat || !GROUP_CHAT_TYPES.has(chat.type)) {
+      return;
+    }
+
+    const chatId = String(chat.id);
+    if (this.seenChatIds.has(chatId)) {
+      // Already recorded this process lifetime — no DB hit.
+      return;
+    }
+
+    // Mark as seen immediately so concurrent updates for the same group don't
+    // each fire an upsert before the first one resolves.
+    this.seenChatIds.add(chatId);
+
+    const title = 'title' in chat && typeof chat.title === 'string' ? chat.title : null;
+    const chatType = chat.type;
+
+    // Fire-and-forget; failures are logged and the chat_id is re-armed so a
+    // later update can retry the write.
+    void this.upsertGroup(chatId, title, chatType).catch((error) => {
+      this.seenChatIds.delete(chatId);
+      this.logger.warn(`Failed to upsert captured group ${chatId}: ${String(error)}`);
+    });
+  }
+
+  /**
+   * Upserts a captured group by `chat_id`, refreshing title/type and last_seen_at.
+   * @param {string} chatId - Telegram chat id (string)
+   * @param {string | null} title - Group title
+   * @param {string} chatType - Telegram chat type
+   * @private
+   */
+  private async upsertGroup(chatId: string, title: string | null, chatType: string): Promise<void> {
+    await this.knexService
+      .knex(TABLE_NAME)
+      .insert({
+        chat_id: chatId,
+        title,
+        chat_type: chatType,
+      })
+      .onConflict('chat_id')
+      .merge({
+        title,
+        chat_type: chatType,
+        last_seen_at: this.knexService.knex.fn.now(),
+      });
+  }
+
+  /**
+   * Returns every captured group for the rsvpizza export endpoint.
+   * @returns {Promise<ICapturedGroup[]>} All captured groups
+   */
+  async getAllCapturedGroups(): Promise<ICapturedGroup[]> {
+    return this.knexService
+      .knex<ICapturedGroup>(TABLE_NAME)
+      .select('id', 'chat_id', 'title', 'chat_type', 'first_seen_at', 'last_seen_at')
+      .orderBy('last_seen_at', 'desc');
+  }
+}

--- a/src/modules/city/city.controller.ts
+++ b/src/modules/city/city.controller.ts
@@ -1,0 +1,106 @@
+/**
+ * @fileoverview City controller for handling city-related HTTP requests
+ * @module city.controller
+ */
+
+import {
+  Controller,
+  Get,
+  UseGuards,
+  UnauthorizedException,
+  Injectable,
+  CanActivate,
+  ExecutionContext,
+} from '@nestjs/common';
+import { Request } from 'express';
+import { CityService } from './city.service';
+import { CountryService } from '../country/country.service';
+import { RegionService } from '../region/region.service';
+
+/**
+ * Guard for protecting the rsvpizza city export route with API key authentication
+ * @class RsvpizzaApiKeyGuard
+ * @implements {CanActivate}
+ * @description Validates the presence and correctness of the API key in request
+ * headers. Mirrors the existing `ApiKeyGuard` used by {@link UserController} but
+ * authorizes against the dedicated `RSVPIZZA_API_KEY` env (and still accepts the
+ * shared `USER_API_KEY` for backwards-compatible internal callers).
+ */
+@Injectable()
+class RsvpizzaApiKeyGuard implements CanActivate {
+  /**
+   * Validates the API key from request headers
+   * @param {ExecutionContext} context - The execution context
+   * @returns {boolean} True if the API key is valid
+   * @throws {UnauthorizedException} If the API key is invalid or missing
+   */
+  canActivate(context: ExecutionContext): boolean {
+    const request: Request = context.switchToHttp().getRequest<Request>();
+    const apiKey = request.headers['x-api-key'];
+    if (
+      apiKey &&
+      (apiKey === process.env.RSVPIZZA_API_KEY || apiKey === process.env.USER_API_KEY)
+    ) {
+      return true;
+    }
+    throw new UnauthorizedException('Invalid API key');
+  }
+}
+
+/**
+ * Shape of a single city entry returned by the `/city/groups` export
+ * @interface ICityGroupExport
+ */
+interface ICityGroupExport {
+  cityName: string;
+  countryName: string;
+  regionName: string;
+  groupId: string;
+  telegramLink: string;
+}
+
+/**
+ * Controller for handling city-related HTTP requests
+ * @class CityController
+ * @description Provides endpoints for exporting city data to external integrations
+ */
+@Controller('city')
+export class CityController {
+  constructor(
+    private readonly cityService: CityService,
+    private readonly countryService: CountryService,
+    private readonly regionService: RegionService,
+  ) {}
+
+  /**
+   * Exports all cities with their Telegram group ids and links, joined with
+   * their country and region names, for rsvpizza to sync host announcements from.
+   * @returns {Promise<{ cities: ICityGroupExport[] }>} Exported city groups
+   * @protected Requires valid `RSVPIZZA_API_KEY` (or `USER_API_KEY`) in `x-api-key`
+   */
+  @UseGuards(RsvpizzaApiKeyGuard)
+  @Get('groups')
+  async getCityGroups(): Promise<{ cities: ICityGroupExport[] }> {
+    const cities = await this.cityService.getAllCitiesWithLinks();
+    const countries = await this.countryService.getAllCountries();
+    const regions = await this.regionService.getAllRegions();
+
+    const countryById = new Map(countries.map((c) => [c.id, c]));
+    const regionById = new Map(regions.map((r) => [r.id, r]));
+
+    const result: ICityGroupExport[] = cities.map((city) => {
+      const country = city.country_id ? countryById.get(city.country_id) : undefined;
+      const region = country?.region_id ? regionById.get(country.region_id) : undefined;
+
+      return {
+        cityName: city.name ?? '',
+        countryName: country?.name ?? '',
+        regionName: region?.name ?? '',
+        groupId: city.group_id ?? '',
+        telegramLink: city.telegram_link ?? '',
+      };
+    });
+
+    return { cities: result };
+  }
+}

--- a/src/modules/city/city.module.ts
+++ b/src/modules/city/city.module.ts
@@ -5,7 +5,10 @@
 
 import { Module } from '@nestjs/common';
 import { CityService } from './city.service';
+import { CityController } from './city.controller';
 import { KnexModule } from '../knex/knex.module';
+import { CountryModule } from '../country/country.module';
+import { RegionModule } from '../region/region.module';
 
 /**
  * Module for managing city data and operations
@@ -14,8 +17,9 @@ import { KnexModule } from '../knex/knex.module';
  * cities by country and managing city data
  */
 @Module({
-  imports: [KnexModule],
+  imports: [KnexModule, CountryModule, RegionModule],
   providers: [CityService],
+  controllers: [CityController],
   exports: [CityService],
 })
 export class CityModule {}

--- a/src/modules/city/city.service.ts
+++ b/src/modules/city/city.service.ts
@@ -41,6 +41,30 @@ export class CityService {
   }
 
   /**
+   * Retrieves all cities including their Telegram group id and link
+   * @returns {Promise<ICity[]>} Array of all cities with `group_id` + `telegram_link`
+   * @description Like {@link getAllCities} but also selects `telegram_link`, used by
+   * the `/city/groups` export endpoint. Cached separately under its own key.
+   */
+  async getAllCitiesWithLinks(): Promise<ICity[]> {
+    const cacheKey = 'cities:all:with_links';
+
+    const cachedCities = await RunCache.get(cacheKey);
+
+    if (cachedCities) {
+      return JSON.parse(cachedCities as string) as ICity[];
+    }
+
+    const cities = await this.knexService
+      .knex<ICity>('city')
+      .select('id', 'name', 'group_id', 'telegram_link', 'country_id');
+
+    await RunCache.set({ key: cacheKey, value: JSON.stringify(cities) });
+
+    return cities;
+  }
+
+  /**
    * Retrieves all cities in a specific country
    * @param {string} countryId - The ID of the country
    * @returns {Promise<ICity[]>} Array of cities in the country

--- a/src/modules/common/common.module.ts
+++ b/src/modules/common/common.module.ts
@@ -12,6 +12,7 @@ import { CommonService } from './common.service';
 import { BroadcastModule } from '../broadcast/broadcast.module';
 import { UserModule } from '../user/user.module';
 import { AccessModule } from '../access/access.module';
+import { HostInboundModule } from '../host-inbound/host-inbound.module';
 
 /**
  * Module for shared functionality across the application
@@ -28,6 +29,7 @@ import { AccessModule } from '../access/access.module';
     AccessModule,
     forwardRef(() => BroadcastModule),
     UserModule,
+    forwardRef(() => HostInboundModule),
   ],
   providers: [CommonService],
   exports: [CommonService],

--- a/src/modules/common/common.service.ts
+++ b/src/modules/common/common.service.ts
@@ -9,6 +9,7 @@ import { forwardRef, Inject, Injectable } from '@nestjs/common';
 import { Help, On, Update } from 'nestjs-telegraf';
 import { WelcomeService } from '../welcome/welcome.service';
 import { BroadcastService } from '../broadcast/broadcast.service';
+import { HostInboundService } from '../host-inbound/host-inbound.service';
 import { TUserFlow, IUserState } from './common.interface';
 import { getContextTelegramUserId } from 'src/utils/context';
 
@@ -29,6 +30,8 @@ export class CommonService {
     private readonly welcomeService: WelcomeService,
     @Inject(forwardRef(() => BroadcastService))
     private readonly broadcastService: BroadcastService,
+    @Inject(forwardRef(() => HostInboundService))
+    private readonly hostInboundService: HostInboundService,
   ) {}
 
   /**
@@ -77,6 +80,12 @@ export class CommonService {
     } else if (state.flow === 'welcome') {
       await this.welcomeService.handlePrivateChat(ctx);
     } else {
+      // Idle / no-active-flow private chat: a bare number (e.g. "120") from a
+      // host is treated as a headcount submission and forwarded to rsvpizza.
+      // Anything else falls through to the existing private-chat handler.
+      const forwarded = await this.hostInboundService.tryForwardBareNumber(ctx);
+      if (forwarded) return;
+
       await this.welcomeService.handlePrivateChat(ctx);
     }
   }

--- a/src/modules/host-inbound/host-inbound.module.ts
+++ b/src/modules/host-inbound/host-inbound.module.ts
@@ -1,0 +1,19 @@
+/**
+ * @fileoverview Module that forwards inbound host DM submissions to rsvpizza.
+ * @module host-inbound.module
+ */
+
+import { forwardRef, Module } from '@nestjs/common';
+import { CommonModule } from '../common/common.module';
+import { HostInboundService } from './host-inbound.service';
+
+/**
+ * Module for forwarding inbound host submissions (photos + headcounts) to rsvpizza.
+ * @class HostInboundModule
+ */
+@Module({
+  imports: [forwardRef(() => CommonModule)],
+  providers: [HostInboundService],
+  exports: [HostInboundService],
+})
+export class HostInboundModule {}

--- a/src/modules/host-inbound/host-inbound.service.ts
+++ b/src/modules/host-inbound/host-inbound.service.ts
@@ -120,6 +120,60 @@ export class HostInboundService {
   }
 
   /**
+   * Forwards an inbound host IMAGE DOCUMENT to rsvpizza when the user is in a
+   * private chat and NOT inside an active broadcast/registration flow.
+   *
+   * Telegram delivers forwarded or uncompressed ("send as file") images as a
+   * `document`, not a `photo`, so the `@On('photo')` handler above never fires
+   * for them and the submission was silently dropped. This mirrors `onHostPhoto`
+   * but reads `ctx.message.document` and only acts on `image/*` MIME types
+   * (PDFs/other files are out of scope — the OCR pipeline is image-vision only).
+   *
+   * It forwards with `kind: 'photo'` because rsvpizza downloads any `file_id`
+   * via getFile and OCRs it identically regardless of how Telegram delivered it.
+   *
+   * This runs alongside the broadcast module's own `@On('document')` handler,
+   * which only acts when `session.step === 'creating_post'` and otherwise returns
+   * early. We additionally guard on private-chat + no-active-session so the two
+   * never collide.
+   * @param {Context} ctx - The Telegraf context.
+   * @returns {Promise<void>}
+   */
+  @On('document')
+  async onHostDocument(@Ctx() ctx: Context): Promise<void> {
+    // Only private chats; never groups.
+    if (ctx.chat?.type !== 'private') return;
+    if (!ctx.from?.id) return;
+    if (!ctx.message || !('document' in ctx.message)) return;
+
+    const doc = ctx.message.document;
+    // Images only — PDFs/other files are out of scope (OCR is image-vision only).
+    const mime = doc.mime_type || '';
+    if (!mime.startsWith('image/')) return;
+
+    const userId = getContextTelegramUserId(ctx);
+    if (!userId) return;
+
+    // Never collide with broadcast post-creation or registration flows.
+    if (!(await this.hasNoActiveSession(userId))) return;
+
+    // Optional instant ack so the bot isn't silent during OCR. rsvpizza sends
+    // the real "✅ added" confirmation.
+    try {
+      await ctx.reply('📥 Got it, processing…');
+    } catch {
+      // Acks are best-effort; ignore failures.
+    }
+
+    await this.forwardHostInbound({
+      chatId: ctx.from.id,
+      kind: 'photo',
+      fileId: doc.file_id,
+      fileUniqueId: doc.file_unique_id,
+    });
+  }
+
+  /**
    * Forwards a BARE NUMBER text DM (e.g. a headcount) to rsvpizza when the user
    * is in a private chat and NOT inside an active flow. Called from
    * CommonService's `@On('message')` idle branch so it doesn't compete with the

--- a/src/modules/host-inbound/host-inbound.service.ts
+++ b/src/modules/host-inbound/host-inbound.service.ts
@@ -1,0 +1,149 @@
+/**
+ * @fileoverview Forwards inbound host DM submissions (receipt/event photos and
+ * bare-number headcounts) from Telegram to the rsvpizza backend, which does all
+ * the downloading, OCR and persistence. moltobene stays thin: it only forwards
+ * `{ chatId, kind, fileId|text }` and lets rsvpizza send the real confirmation DM.
+ * @module host-inbound.service
+ */
+
+import { forwardRef, Inject, Injectable } from '@nestjs/common';
+import { Context } from 'telegraf';
+import { Ctx, On, Update } from 'nestjs-telegraf';
+import axios from 'axios';
+import { CommonService } from '../common/common.service';
+import { getContextTelegramUserId } from 'src/utils/context';
+
+/**
+ * Payload forwarded to rsvpizza's POST /api/telegram/host-inbound endpoint.
+ */
+interface IForwardHostInbound {
+  /** The host's Telegram user id (== chat id for private chats). */
+  chatId: number;
+  /** What kind of submission this is. */
+  kind: 'photo' | 'text';
+  /** Telegram file_id of the largest photo size (photo kind only). */
+  fileId?: string;
+  /** Telegram file_unique_id of the largest photo size (photo kind only). */
+  fileUniqueId?: string;
+  /** Raw text payload (text kind only — currently a bare headcount number). */
+  text?: string;
+}
+
+/**
+ * Service that forwards inbound host submissions to rsvpizza.
+ * @class HostInboundService
+ */
+@Update()
+@Injectable()
+export class HostInboundService {
+  constructor(
+    @Inject(forwardRef(() => CommonService))
+    private readonly commonService: CommonService,
+  ) {}
+
+  /**
+   * POSTs a host submission to rsvpizza. Fire-and-forget-ish: never throws, just
+   * logs on failure so a flaky rsvpizza never crashes the bot. rsvpizza is
+   * responsible for replying to the host with the real confirmation.
+   * @param {IForwardHostInbound} body - The payload to forward.
+   * @returns {Promise<boolean>} True on a 2xx, false otherwise.
+   */
+  async forwardHostInbound(body: IForwardHostInbound): Promise<boolean> {
+    try {
+      await axios.post(`${process.env.RSVPIZZA_BASE_URL}/api/telegram/host-inbound`, body, {
+        headers: { 'x-api-key': process.env.TELEGRAM_LINK_CALLBACK_SECRET ?? '' },
+      });
+      return true;
+    } catch (error) {
+      console.error('Failed to forward host inbound submission to rsvpizza:', error);
+      return false;
+    }
+  }
+
+  /**
+   * Returns true when the user is NOT inside an active broadcast/registration
+   * flow, i.e. when a private-chat message should be treated as a host
+   * submission rather than flow input.
+   * @param {string | number} userId - The Telegram user id.
+   * @returns {Promise<boolean>}
+   * @private
+   */
+  private async hasNoActiveSession(userId: string | number): Promise<boolean> {
+    const state = await this.commonService.getUserState(Number(userId));
+    // No state at all, or an explicitly idle flow with no in-progress step.
+    return !state || ((!state.flow || state.flow === 'idle') && !state.step);
+  }
+
+  /**
+   * Forwards an inbound host PHOTO to rsvpizza when the user is in a private chat
+   * and NOT inside an active broadcast/registration flow.
+   *
+   * This runs alongside the broadcast module's own `@On('photo')` handler
+   * (`BroadcastService.onPhoto`), which only acts when `session.step ===
+   * 'creating_post'` and otherwise returns early. We additionally guard on
+   * private-chat + no-active-session so the two never collide.
+   * @param {Context} ctx - The Telegraf context.
+   * @returns {Promise<void>}
+   */
+  @On('photo')
+  async onHostPhoto(@Ctx() ctx: Context): Promise<void> {
+    // Only private chats; never groups.
+    if (ctx.chat?.type !== 'private') return;
+    if (!ctx.from?.id) return;
+    if (!ctx.message || !('photo' in ctx.message) || ctx.message.photo.length === 0) return;
+
+    const userId = getContextTelegramUserId(ctx);
+    if (!userId) return;
+
+    // Never collide with broadcast post-creation or registration flows.
+    if (!(await this.hasNoActiveSession(userId))) return;
+
+    const p = ctx.message.photo;
+    const best = p[p.length - 1];
+    const fileId = best.file_id;
+    const fileUniqueId = best.file_unique_id;
+
+    // Optional instant ack so the bot isn't silent during OCR. rsvpizza sends
+    // the real "✅ added" confirmation.
+    try {
+      await ctx.reply('📥 Got it, processing…');
+    } catch {
+      // Acks are best-effort; ignore failures.
+    }
+
+    await this.forwardHostInbound({
+      chatId: ctx.from.id,
+      kind: 'photo',
+      fileId,
+      fileUniqueId,
+    });
+  }
+
+  /**
+   * Forwards a BARE NUMBER text DM (e.g. a headcount) to rsvpizza when the user
+   * is in a private chat and NOT inside an active flow. Called from
+   * CommonService's `@On('message')` idle branch so it doesn't compete with the
+   * registration/edit text handlers in WelcomeService.handlePrivateChat.
+   * @param {Context} ctx - The Telegraf context.
+   * @returns {Promise<boolean>} True if the message was handled as a headcount.
+   */
+  async tryForwardBareNumber(ctx: Context): Promise<boolean> {
+    if (ctx.chat?.type !== 'private') return false;
+    if (!ctx.from?.id) return false;
+    if (!ctx.message || !('text' in ctx.message) || typeof ctx.message.text !== 'string') {
+      return false;
+    }
+
+    const text = ctx.message.text.trim();
+    if (!/^\d{1,6}$/.test(text)) return false;
+
+    const userId = getContextTelegramUserId(ctx);
+    if (!userId) return false;
+
+    // Belt-and-suspenders: caller already checks idle, re-check here.
+    if (!(await this.hasNoActiveSession(userId))) return false;
+
+    await this.forwardHostInbound({ chatId: ctx.from.id, kind: 'text', text });
+    return true;
+  }
+}

--- a/src/modules/host-inbound/host-inbound.service.ts
+++ b/src/modules/host-inbound/host-inbound.service.ts
@@ -25,6 +25,14 @@ interface IForwardHostInbound {
   fileId?: string;
   /** Telegram file_unique_id of the largest photo size (photo kind only). */
   fileUniqueId?: string;
+  /**
+   * MIME type of the forwarded document (photo kind only, document path).
+   * Used by rsvpizza to detect PDFs (`application/pdf`) which it must rasterize
+   * to an image before OCR (gpt-4o vision can't read a PDF via image_url).
+   * Absent for compressed photos and image documents (rsvpizza treats those as
+   * plain images). suppli-58533.
+   */
+  mimeType?: string;
   /** Raw text payload (text kind only — currently a bare headcount number). */
   text?: string;
 }
@@ -126,11 +134,14 @@ export class HostInboundService {
    * Telegram delivers forwarded or uncompressed ("send as file") images as a
    * `document`, not a `photo`, so the `@On('photo')` handler above never fires
    * for them and the submission was silently dropped. This mirrors `onHostPhoto`
-   * but reads `ctx.message.document` and only acts on `image/*` MIME types
-   * (PDFs/other files are out of scope — the OCR pipeline is image-vision only).
+   * but reads `ctx.message.document` and acts on `image/*` MIME types AND
+   * `application/pdf` (suppli-58533: hosts often have PDF receipts). Other file
+   * types stay out of scope.
    *
-   * It forwards with `kind: 'photo'` because rsvpizza downloads any `file_id`
-   * via getFile and OCRs it identically regardless of how Telegram delivered it.
+   * It forwards with `kind: 'photo'` (plus a `mimeType` so rsvpizza can tell a
+   * PDF from an image) because rsvpizza downloads any `file_id` via getFile and
+   * handles it from there — OCRing images directly and rasterizing PDFs to an
+   * image first before OCR.
    *
    * This runs alongside the broadcast module's own `@On('document')` handler,
    * which only acts when `session.step === 'creating_post'` and otherwise returns
@@ -147,9 +158,14 @@ export class HostInboundService {
     if (!ctx.message || !('document' in ctx.message)) return;
 
     const doc = ctx.message.document;
-    // Images only — PDFs/other files are out of scope (OCR is image-vision only).
+    // Accept images AND PDFs (suppli-58533). Belt-and-suspenders: some clients
+    // send a PDF with an empty/wrong mime_type, so also sniff the .pdf extension
+    // off the file_name. Everything else stays out of scope.
     const mime = doc.mime_type || '';
-    if (!mime.startsWith('image/')) return;
+    const fileName = doc.file_name || '';
+    const isImage = mime.startsWith('image/');
+    const isPdf = mime === 'application/pdf' || /\.pdf$/i.test(fileName);
+    if (!isImage && !isPdf) return;
 
     const userId = getContextTelegramUserId(ctx);
     if (!userId) return;
@@ -170,6 +186,8 @@ export class HostInboundService {
       kind: 'photo',
       fileId: doc.file_id,
       fileUniqueId: doc.file_unique_id,
+      // Tell rsvpizza the real type so it can rasterize PDFs before OCR.
+      mimeType: isPdf ? 'application/pdf' : mime || undefined,
     });
   }
 

--- a/src/modules/user/user.service.ts
+++ b/src/modules/user/user.service.ts
@@ -105,4 +105,13 @@ export class UserService {
 
     return !!existingPizzaName;
   }
+
+  async isDiscordNameExists(discordName: string): Promise<boolean> {
+    const existing: IUser | undefined = await this.knexService
+      .knex<IUser>('user')
+      .where('discord_name', discordName)
+      .first();
+
+    return !!existing;
+  }
 }

--- a/src/modules/welcome/welcome.service.ts
+++ b/src/modules/welcome/welcome.service.ts
@@ -185,10 +185,17 @@ export class WelcomeService {
       });
 
       return;
-    } else if (startPayload && startPayload.startsWith('rsvp_')) {
-      // Deep link from rsvpizza: link this Telegram chat to a host's event so they
-      // receive PizzaDAO host announcements. Confirms the link back to rsvpizza.
-      const token = startPayload.slice(5);
+    } else if (
+      startPayload &&
+      (startPayload.startsWith('rsvp_') || startPayload.startsWith('submit_'))
+    ) {
+      // Deep link from rsvpizza: link this Telegram chat to a host's event.
+      //  - rsvp_<token>   → host opts in to PizzaDAO announcements.
+      //  - submit_<token> → unlinked host (reached via the group chat) connects
+      //    so they can reply with receipts/photos/headcount and have moltobene
+      //    forward them to rsvpizza. Same link-host call; submission-flavored reply.
+      const isSubmit = startPayload.startsWith('submit_');
+      const token = isSubmit ? startPayload.slice(7) : startPayload.slice(5);
       const chatId = ctx.from?.id;
 
       try {
@@ -203,9 +210,16 @@ export class WelcomeService {
         const data = (response.data ?? {}) as { ok?: boolean; partyName?: string };
 
         if (data.ok) {
-          await ctx.reply(
-            "✅ Connected — you'll now receive PizzaDAO host announcements.",
-          );
+          if (isSubmit) {
+            await ctx.replyWithMarkdownV2(
+              "You're connected\\! 🍕 Now just send me your *receipt photo*, an *event photo*, " +
+                "or type your *headcount*, and I'll add it to your event — no login needed\\.",
+            );
+          } else {
+            await ctx.reply(
+              "✅ Connected — you'll now receive PizzaDAO host announcements.",
+            );
+          }
         } else {
           await ctx.reply(
             'That link is invalid or expired — ask your underboss for a fresh one.',

--- a/src/modules/welcome/welcome.service.ts
+++ b/src/modules/welcome/welcome.service.ts
@@ -13,9 +13,9 @@ import { MembershipService } from '../membership/membership.service';
 import { CommonService } from '../common/common.service';
 import { IUser } from '../user/user.interface';
 import { IUserRegistrationData } from './welcome.interface';
-import OpenAI from 'openai';
 import { getContextTelegramUserId } from 'src/utils/context';
 import axios from 'axios';
+import OpenAI from 'openai';
 
 /**
  * Service class that handles all welcome-related functionality
@@ -26,9 +26,6 @@ import axios from 'axios';
 @Update()
 @Injectable()
 export class WelcomeService {
-  /** OpenAI instance for generating pizza names */
-  private readonly openAi: OpenAI;
-
   /** Collection of welcome messages with placeholders for pizza name and group name */
   private readonly welcomeMessages: string[] = [
     '🍕 Welcome <pizza_name> to <group_name> Chat! The crust is strong with this one.',
@@ -61,6 +58,11 @@ export class WelcomeService {
   /** Map to store user registration data during the registration process */
   private userGroupMap = new Map<string, IUserRegistrationData>();
 
+  private readonly openAi: OpenAI | null =
+    process.env.PIZZA_NAME_GENERATION_ENABLED === 'true' && process.env.OPENAI_API_KEY
+      ? new OpenAI({ apiKey: process.env.OPENAI_API_KEY })
+      : null;
+
   /**
    * Creates an instance of WelcomeService
    * @param {UserService} userService - Service for user management
@@ -76,11 +78,7 @@ export class WelcomeService {
     private readonly membershipService: MembershipService,
     @Inject(forwardRef(() => CommonService))
     private readonly commonService: CommonService,
-  ) {
-    this.openAi = new OpenAI({
-      apiKey: process.env.OPENAI_API_KEY,
-    });
-  }
+  ) {}
 
   /**
    * Handles the /start command from users
@@ -172,13 +170,15 @@ export class WelcomeService {
         reply_markup: {
           inline_keyboard: [
             [{ text: 'Yes I have a Pizza Name 🍕', callback_data: 'has_pizza_name' }],
+            ...(this.openAi
+              ? [[{ text: 'Generate a Pizza Name 🤖', callback_data: 'give_me_pizza_name' }]]
+              : [[{ text: "I don't have a Pizza Name 🍕", url: 'https://pizzadao.org/' }]]),
             [
               {
                 text: 'Join Discord',
                 url: 'https://discord.gg/rwthAq3e?event=1366460552074756220',
               },
             ],
-            [{ text: 'Give me a Pizza Name', callback_data: 'give_me_pizza_name' }],
           ],
         },
         parse_mode: 'MarkdownV2',
@@ -190,7 +190,13 @@ export class WelcomeService {
         await this.handleProfile(ctx);
       } else {
         if (!process.env.WELCOME_VIDEO_ID) {
-          await ctx.reply('❌ Welcome video is not available.');
+          await ctx.reply('❌ Welcome video is not available.', {
+            reply_markup: {
+              inline_keyboard: [
+                [{ text: 'Explore Party Cities 🎉', callback_data: 'explore_cities' }],
+              ],
+            },
+          });
           return;
         }
         await ctx.telegram.sendVideo(ctx.chat?.id ?? 0, process.env.WELCOME_VIDEO_ID, {
@@ -622,17 +628,15 @@ export class WelcomeService {
       });
     }
 
-    // CallBackQuery[Register User]: Handle 'Give me a Pizza Name' button
-    if (callbackData === 'give_me_pizza_name') {
+    // CallBackQuery[Register User]: Handle 'Generate a Pizza Name' button (only when feature is enabled)
+    if (callbackData === 'give_me_pizza_name' && this.openAi) {
       await ctx.deleteMessage();
       await this.commonService.setUserState(Number(userId), {
         flow: 'welcome',
         step: 'pizza_topping',
       });
       await ctx.reply('🍕 *What is your favorite pizza topping?*', {
-        reply_markup: {
-          force_reply: true,
-        },
+        reply_markup: { force_reply: true },
         parse_mode: 'MarkdownV2',
       });
     }
@@ -1069,110 +1073,6 @@ export class WelcomeService {
   }
 
   /**
-   * Generates a pizza name using OpenAI
-   * @param {string} pizzaTopping - The user's preferred pizza topping
-   * @param {string} mafiaMovie - The user's favorite mafia movie
-   * @param {string} [existingPizzaName] - Optional existing pizza name to avoid duplicates
-   * @param {number} [attempt=1] - Current attempt number for name generation
-   * @returns {Promise<string | null>} The generated pizza name or null if generation fails
-   * @private
-   */
-  private async generatePizzaName(
-    pizzaTopping: string,
-    mafiaMovie: string,
-    existingPizzaName?: string,
-    attempt: number = 1,
-  ): Promise<string | null> {
-    if (attempt > 5) {
-      console.warn('Exceeded maximum attempts to generate a unique pizza name.');
-      return null; // Return null if the recursion limit is reached
-    }
-
-    const prompt = `Come up with a fun and creative pizza name by combining the topping "${pizzaTopping}" with a last name of a cast member from the mafia movie "${mafiaMovie}". Randomize the chosen character from this number ${new Date().getTime()}. Use the topping as the first name and the last name of a cast member from the movie as the surname. Make it sound like a quirky mafia-style name.${
-      existingPizzaName ? ` Avoid using the existing pizza name "${existingPizzaName}".` : ''
-    } Just output the name without quotes.`;
-
-    try {
-      const response = await this.openAi.chat.completions.create({
-        model: 'gpt-4o-mini',
-        messages: [{ role: 'user', content: prompt }],
-        temperature: 0.7,
-        max_tokens: 50,
-      });
-
-      const generatedPizzaName =
-        response.choices[0]?.message?.content?.trim() || 'Unknown Pizza Name';
-
-      const isPizzaNameExists = await this.userService.isPizzaNameExists(generatedPizzaName);
-
-      if (isPizzaNameExists && existingPizzaName === generatedPizzaName) {
-        return null;
-      }
-
-      if (isPizzaNameExists) {
-        return this.generatePizzaName(pizzaTopping, mafiaMovie, generatedPizzaName, attempt + 1);
-      }
-
-      return generatedPizzaName;
-    } catch (error) {
-      console.error('Error generating pizza name:', error);
-      return 'Unknown Pizza Name';
-    }
-  }
-
-  /**
-   * Validates if a movie name is a valid mafia movie
-   * @param {string} movieName - The movie name to validate
-   * @returns {Promise<boolean>} True if the movie is valid, false otherwise
-   * @private
-   */
-  private async validateMafiaMovie(movieName: string): Promise<boolean> {
-    const prompt = `is ${movieName} a mafia movie, output only 'yes' or 'no'`;
-
-    try {
-      const response = await this.openAi.chat.completions.create({
-        model: 'gpt-4o-mini',
-        messages: [{ role: 'user', content: prompt }],
-        temperature: 0,
-        max_tokens: 5,
-      });
-
-      const result = response.choices[0]?.message?.content?.trim().toLowerCase();
-
-      return result === 'yes';
-    } catch (error) {
-      console.error('Error validating mafia movie:', error);
-      return false;
-    }
-  }
-
-  /**
-   * Validates if a pizza topping is valid
-   * @param {string} pizzaTopping - The pizza topping to validate
-   * @returns {Promise<boolean>} True if the topping is valid, false otherwise
-   * @private
-   */
-  private async validatePizzaTopping(pizzaTopping: string): Promise<boolean> {
-    const prompt = `is ${pizzaTopping} a pizza topping, output only 'yes' or 'no'`;
-
-    try {
-      const response = await this.openAi.chat.completions.create({
-        model: 'gpt-4o-mini',
-        messages: [{ role: 'user', content: prompt }],
-        temperature: 0,
-        max_tokens: 5,
-      });
-
-      const result = response.choices[0]?.message?.content?.trim().toLowerCase();
-
-      return result === 'yes';
-    } catch (error) {
-      console.error('Error validating mafia movie:', error);
-      return false;
-    }
-  }
-
-  /**
    * Handles region selection
    * @param {Context} ctx - The Telegraf context object
    * @returns {Promise<void>}
@@ -1307,142 +1207,184 @@ export class WelcomeService {
       });
     } else if (step === 'discord_username') {
       if ('text' in ctx.message!) {
-        userData.discord_name = ctx.message.text;
+        const enteredDiscordName = ctx.message.text;
+
+        const isDuplicate = await this.userService.isDiscordNameExists(enteredDiscordName);
+        if (isDuplicate) {
+          await ctx.reply(
+            `❌ The Discord username *${enteredDiscordName}* is already registered\\. Please enter a different one:`,
+            { reply_markup: { force_reply: true }, parse_mode: 'MarkdownV2' },
+          );
+          return;
+        }
+
+        userData.discord_name = enteredDiscordName;
       } else {
         await ctx.reply('Invalid input. Please provide a valid Discord username.');
         return;
       }
 
       await this.handleNinjaTurtleMessage(ctx);
-    } else if (step === 'pizza_topping') {
-      if ('text' in ctx.message!) {
-        const enteredPizzaTopping = ctx.message.text;
-
-        const isValidPizzaTopping = await this.validatePizzaTopping(enteredPizzaTopping);
-
-        if (!isValidPizzaTopping) {
-          await ctx.reply(
-            '❌ What you entered is not a pizza topping. Please choose something else.',
-          );
-          await ctx.reply('🍕 *What is your favorite pizza topping?*', {
-            reply_markup: {
-              force_reply: true,
-            },
-            parse_mode: 'MarkdownV2',
-          });
-          return;
-        }
-
-        userData.pizza_topping = enteredPizzaTopping;
-      } else {
+    } else if (step === 'pizza_topping' && this.openAi) {
+      if (!('text' in ctx.message!)) {
         await ctx.reply('Invalid input. Please provide a valid name.');
         return;
       }
+
+      const enteredPizzaTopping = ctx.message.text;
+      const isValidPizzaTopping = await this.validatePizzaTopping(enteredPizzaTopping);
+
+      if (!isValidPizzaTopping) {
+        await ctx.reply('❌ What you entered is not a pizza topping. Please choose something else.');
+        await ctx.reply('🍕 *What is your favorite pizza topping?*', {
+          reply_markup: { force_reply: true },
+          parse_mode: 'MarkdownV2',
+        });
+        return;
+      }
+
+      if (userData) userData.pizza_topping = enteredPizzaTopping;
+
       await this.commonService.setUserState(Number(userId), {
         flow: 'welcome',
         step: 'enter_mafia_movie',
       });
       await ctx.reply('🎥 *What is your favorite Mafia movie?*', {
-        reply_markup: {
-          force_reply: true,
-        },
+        reply_markup: { force_reply: true },
         parse_mode: 'MarkdownV2',
       });
-    } else if (step === 'enter_mafia_movie') {
-      if ('text' in ctx.message!) {
-        const enteredMovie = ctx.message.text;
-
-        const isValidMafiaMovie = await this.validateMafiaMovie(enteredMovie);
-
-        if (!isValidMafiaMovie) {
-          await ctx.reply(
-            '❌ What you entered is not a mafia movie. Please choose something else.',
-          );
-          await ctx.reply('🎥 *What is your favorite Mafia movie?*', {
-            reply_markup: {
-              force_reply: true,
-            },
-            parse_mode: 'MarkdownV2',
-          });
-          return;
-        }
-
-        // If valid, save the movie and proceed
-        userData.mafia_movie = enteredMovie;
-
-        await this.handlePizzaNameGeneration(ctx);
-      } else {
+    } else if (step === 'enter_mafia_movie' && this.openAi) {
+      if (!('text' in ctx.message!)) {
         await ctx.reply('Invalid input. Please provide a valid topping name.');
         return;
       }
+
+      const enteredMovie = ctx.message.text;
+      const isValidMafiaMovie = await this.validateMafiaMovie(enteredMovie);
+
+      if (!isValidMafiaMovie) {
+        await ctx.reply('❌ What you entered is not a mafia movie. Please choose something else.');
+        await ctx.reply('🎥 *What is your favorite Mafia movie?*', {
+          reply_markup: { force_reply: true },
+          parse_mode: 'MarkdownV2',
+        });
+        return;
+      }
+
+      if (userData) userData.mafia_movie = enteredMovie;
+      await this.handlePizzaNameGeneration(ctx);
     }
   }
 
-  /**
-   * Handles pizza name generation process
-   * @param {Context} ctx - The Telegraf context object
-   * @returns {Promise<void>}
-   * @description Manages the generation of pizza names using OpenAI
-   */
+  private async generatePizzaName(
+    pizzaTopping: string,
+    mafiaMovie: string,
+    existingPizzaName?: string,
+    attempt: number = 1,
+  ): Promise<string | null> {
+    if (!this.openAi || attempt > 5) return null;
+
+    const prompt = `Come up with a fun and creative pizza name by combining the topping "${pizzaTopping}" with a last name of a cast member from the mafia movie "${mafiaMovie}". Randomize the chosen character from this number ${new Date().getTime()}. Use the topping as the first name and the last name of a cast member from the movie as the surname. Make it sound like a quirky mafia-style name.${
+      existingPizzaName ? ` Avoid using the existing pizza name "${existingPizzaName}".` : ''
+    } Just output the name without quotes.`;
+
+    try {
+      const response = await this.openAi.chat.completions.create({
+        model: 'gpt-4o-mini',
+        messages: [{ role: 'user', content: prompt }],
+        temperature: 0.7,
+        max_tokens: 50,
+      });
+
+      const generatedPizzaName = response.choices[0]?.message?.content?.trim() || 'Unknown Pizza Name';
+      const isPizzaNameExists = await this.userService.isPizzaNameExists(generatedPizzaName);
+
+      if (isPizzaNameExists && existingPizzaName === generatedPizzaName) return null;
+      if (isPizzaNameExists) {
+        return this.generatePizzaName(pizzaTopping, mafiaMovie, generatedPizzaName, attempt + 1);
+      }
+
+      return generatedPizzaName;
+    } catch (error) {
+      console.error('Error generating pizza name:', error);
+      return null;
+    }
+  }
+
+  private async validateMafiaMovie(movieName: string): Promise<boolean> {
+    if (!this.openAi) return false;
+    try {
+      const response = await this.openAi.chat.completions.create({
+        model: 'gpt-4o-mini',
+        messages: [{ role: 'user', content: `is ${movieName} a mafia movie, output only 'yes' or 'no'` }],
+        temperature: 0,
+        max_tokens: 5,
+      });
+      return response.choices[0]?.message?.content?.trim().toLowerCase() === 'yes';
+    } catch (error) {
+      console.error('Error validating mafia movie:', error);
+      return false;
+    }
+  }
+
+  private async validatePizzaTopping(pizzaTopping: string): Promise<boolean> {
+    if (!this.openAi) return false;
+    try {
+      const response = await this.openAi.chat.completions.create({
+        model: 'gpt-4o-mini',
+        messages: [{ role: 'user', content: `is ${pizzaTopping} a pizza topping, output only 'yes' or 'no'` }],
+        temperature: 0,
+        max_tokens: 5,
+      });
+      return response.choices[0]?.message?.content?.trim().toLowerCase() === 'yes';
+    } catch (error) {
+      console.error('Error validating pizza topping:', error);
+      return false;
+    }
+  }
+
   async handlePizzaNameGeneration(ctx: Context) {
     const userId = getContextTelegramUserId(ctx);
-    if (!userId) return;
+    if (!userId || !this.openAi) return;
 
     const userData = this.userGroupMap.get(userId);
     if (!userData) return;
 
     const { tg_first_name, pizza_topping, mafia_movie } = userData;
-
     if (!tg_first_name || !pizza_topping || !mafia_movie) {
       await ctx.reply('❌ Missing required information to generate a pizza name.');
       return;
     }
 
     const generatingMessage = await ctx.reply('🤖 Generating your pizza name...');
-
-    // Generate the pizza name
     const pizzaName = await this.generatePizzaName(pizza_topping, mafia_movie);
 
     if (!pizzaName) {
       await ctx.telegram.deleteMessage(ctx.chat?.id || 0, generatingMessage.message_id);
-      await ctx.reply(
-        '❌ Failed to generate a unique pizza name. Please try again with another topping or mafia movie.',
-      );
-      await this.commonService.setUserState(Number(userId), {
-        flow: 'welcome',
-        step: 'pizza_topping',
-      });
+      await ctx.reply('❌ Failed to generate a unique pizza name. Please try again with another topping or mafia movie.');
+      await this.commonService.setUserState(Number(userId), { flow: 'welcome', step: 'pizza_topping' });
       await ctx.reply('🍕 *What is your favorite pizza topping?*', {
-        reply_markup: {
-          force_reply: true,
-        },
+        reply_markup: { force_reply: true },
         parse_mode: 'MarkdownV2',
       });
       return;
     }
 
-    // Save the pizza name in the user data
     userData.pizza_name = pizzaName;
-
-    // Send the pizza name message
     await ctx.telegram.deleteMessage(ctx.chat?.id || 0, generatingMessage.message_id);
     const message = await ctx.reply(
-      `🍕 Here's your AI-generated Pizza Name by Molto Benne:\n\n` + `Pizza Name: *${pizzaName}*`,
-      {
-        parse_mode: 'Markdown',
-      },
+      `🍕 Here's your AI-generated Pizza Name by Molto Benne:\n\nPizza Name: *${pizzaName}*`,
+      { parse_mode: 'Markdown' },
     );
 
-    // Pin the message in the chat
     try {
       await ctx.telegram.pinChatMessage(ctx.chat?.id || 0, message.message_id, {
-        disable_notification: true, // Set to false if you want to notify users
+        disable_notification: true,
       });
     } catch (error) {
       console.error('Failed to pin the message:', error);
     }
 
-    // Delay the call to handleNinjaTurtleMessage by 3 seconds
     setTimeout(() => {
       void this.handleNinjaTurtleMessage(ctx);
     }, 3000);

--- a/src/modules/welcome/welcome.service.ts
+++ b/src/modules/welcome/welcome.service.ts
@@ -185,6 +185,40 @@ export class WelcomeService {
       });
 
       return;
+    } else if (startPayload && startPayload.startsWith('rsvp_')) {
+      // Deep link from rsvpizza: link this Telegram chat to a host's event so they
+      // receive PizzaDAO host announcements. Confirms the link back to rsvpizza.
+      const token = startPayload.slice(5);
+      const chatId = ctx.from?.id;
+
+      try {
+        const response = await axios.post(
+          `${process.env.RSVPIZZA_BASE_URL}/api/telegram/link-host`,
+          { token, chatId },
+          {
+            headers: { 'x-api-key': process.env.TELEGRAM_LINK_CALLBACK_SECRET ?? '' },
+          },
+        );
+
+        const data = (response.data ?? {}) as { ok?: boolean; partyName?: string };
+
+        if (data.ok) {
+          await ctx.reply(
+            "✅ Connected — you'll now receive PizzaDAO host announcements.",
+          );
+        } else {
+          await ctx.reply(
+            'That link is invalid or expired — ask your underboss for a fresh one.',
+          );
+        }
+      } catch (error) {
+        console.error('Failed to link rsvpizza host via deep link:', error);
+        await ctx.reply(
+          'That link is invalid or expired — ask your underboss for a fresh one.',
+        );
+      }
+
+      return;
     } else {
       if (await this.userService.isUserRegistered(userId)) {
         await this.handleProfile(ctx);

--- a/src/modules/welcome/welcome.service.ts
+++ b/src/modules/welcome/welcome.service.ts
@@ -1067,7 +1067,7 @@ export class WelcomeService {
 
     try {
       const response = await this.openAi.chat.completions.create({
-        model: 'gpt-4',
+        model: 'gpt-4o-mini',
         messages: [{ role: 'user', content: prompt }],
         temperature: 0.7,
         max_tokens: 50,
@@ -1104,7 +1104,7 @@ export class WelcomeService {
 
     try {
       const response = await this.openAi.chat.completions.create({
-        model: 'gpt-4',
+        model: 'gpt-4o-mini',
         messages: [{ role: 'user', content: prompt }],
         temperature: 0,
         max_tokens: 5,
@@ -1130,7 +1130,7 @@ export class WelcomeService {
 
     try {
       const response = await this.openAi.chat.completions.create({
-        model: 'gpt-4',
+        model: 'gpt-4o-mini',
         messages: [{ role: 'user', content: prompt }],
         temperature: 0,
         max_tokens: 5,

--- a/src/modules/welcome/welcome.service.ts
+++ b/src/modules/welcome/welcome.service.ts
@@ -293,6 +293,33 @@ export class WelcomeService {
     );
   }
 
+  @Command('chatid')
+  async handleChatId(ctx: Context) {
+    const chatId = ctx.chat?.id;
+    const userMessageId = ctx.message?.message_id;
+
+    if (!chatId) return;
+
+    const botResponse = await ctx.reply(`Chat ID: \`${chatId}\``, {
+      parse_mode: 'Markdown',
+    });
+
+    setTimeout(() => {
+      void (async () => {
+        try {
+          if (userMessageId) {
+            await ctx.telegram.deleteMessage(chatId, userMessageId).catch(() => {
+              // Ignore failure if bot isn't admin
+            });
+          }
+          await ctx.telegram.deleteMessage(chatId, botResponse.message_id);
+        } catch (error) {
+          console.error('Failed to auto-delete chatid messages:', error);
+        }
+      })();
+    }, 30000);
+  }
+
   /**
    * Handles new user registration process
    * @param {Context} ctx - The Telegraf context object


### PR DESCRIPTION
**moltobene (bot) side of the suppli-58533 PDF-receipt feature.**

Hosts often send receipts as PDFs. The `onHostDocument` host-inbound handler previously dropped anything that wasn't `image/*` (OCR pipeline was image-vision only). This change:

- Accepts `application/pdf` documents (plus a `.pdf` file-name extension sniff as a belt-and-suspenders fallback when Telegram's `mime_type` is empty/wrong).
- Forwards them with the existing `kind:'photo'` plus a **new `mimeType` field** on the host-inbound payload, so rsvpizza can tell a PDF from an image.
- Image/photo paths are 100% unchanged.

rsvpizza does the actual work (gpt-4o vision can't read a PDF via `image_url`, so it must rasterize page 1 to a PNG before OCR). **This PR pairs with the rsvpizza-side PDF-rasterize-for-OCR PR** (pdfjs-dist + @napi-rs/canvas) — that lives in the rsvpizza backend repo, not here.

No new deps; `nest build` is clean. Bot auto-deploys from main on Railway.

🤖 Generated with [Claude Code](https://claude.com/claude-code)